### PR TITLE
Fixed incorrect phase angle

### DIFF
--- a/InterplanetaryCalc/InterplanetaryCalc.cs
+++ b/InterplanetaryCalc/InterplanetaryCalc.cs
@@ -224,7 +224,7 @@ namespace InterplanetaryCalc
             double transfer;
             
             transfer = 180 - ((time / targetOrbit.period) * 360);
-            if (transfer < -180) { transfer += 360; }
+            while (transfer < -180) {transfer += 360;}
             return Math.Round(transfer, 1);
         }
         double DeltaV()


### PR DESCRIPTION
Angle clamp now uses iteration instead of one fixed addition of 360 degrees - might be more costly but fixed nonetheless.